### PR TITLE
修复 ChatNavigationBar Extra argument 'frame' in call

### DIFF
--- a/EaseChatDemo/EaseChatDemo/IntegratedFromEaseChatUIKit/Controllers/MineCallInviteUsersController.swift
+++ b/EaseChatDemo/EaseChatDemo/IntegratedFromEaseChatUIKit/Controllers/MineCallInviteUsersController.swift
@@ -33,7 +33,7 @@ final class MineCallInviteUsersController: GroupParticipantsRemoveController {
     }
     
     override func createNavigation() -> ChatNavigationBar {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: 44),textAlignment: .left,rightTitle: "Confirm".chat.localize)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: 44),textAlignment: .left,rightTitle: "Confirm".chat.localize)
     }
     
     override func viewDidLoad() {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/AboutEasemobController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/AboutEasemobController.swift
@@ -20,7 +20,7 @@ final class AboutEasemobController: UIViewController {
     ]
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
     }()
     
     private lazy var header: AboutEasemobHeader = {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/ColorSettingViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/ColorSettingViewController.swift
@@ -21,7 +21,7 @@ final class ColorSettingViewController: UIViewController {
     }
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: "Confirm".chat.localize)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: "Confirm".chat.localize)
     }()
     
     private lazy var infoList: UITableView = {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/FeatureSwitchViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/FeatureSwitchViewController.swift
@@ -29,7 +29,7 @@ final class FeatureSwitchViewController: UIViewController {
     }()
 
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
     }()
     
     private lazy var featureList: UITableView = {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/GeneralViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/GeneralViewController.swift
@@ -40,7 +40,7 @@ final class GeneralViewController: UIViewController {
     }()
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
     }()
     
     private lazy var menuList: UITableView = {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/LanguageSettingViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/LanguageSettingViewController.swift
@@ -17,7 +17,7 @@ final class LanguageSettingViewController: UIViewController {
     private var languageRawValues = ["zh-Hans","en"]
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left,rightTitle: "Confirm".chat.localize)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left,rightTitle: "Confirm".chat.localize)
     }()
     
     private lazy var infoList: UITableView = {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/NotificationSettingViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/NotificationSettingViewController.swift
@@ -11,7 +11,7 @@ import EaseChatUIKit
 final class NotificationSettingViewController: UIViewController {
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left)
     }()
     
     private lazy var container: UIView = {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/PrivacyPolicyViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/PrivacyPolicyViewController.swift
@@ -11,7 +11,7 @@ import EaseChatUIKit
 final class PrivacyPolicyViewController: UIViewController {
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
     }()
 
     override func viewDidLoad() {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/PrivacySettingViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/PrivacySettingViewController.swift
@@ -27,7 +27,7 @@ final class PrivacySettingViewController: UIViewController {
     }()
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight), textAlignment: .left, rightTitle: nil)
     }()
     
     private lazy var featureList: UITableView = {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/ShowMenuStyleViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/ShowMenuStyleViewController.swift
@@ -26,7 +26,7 @@ final class ShowMenuStyleViewController: UIViewController {
     private var styleRawValue: UInt8 = 0
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left,rightTitle: "Confirm".chat.localize)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left,rightTitle: "Confirm".chat.localize)
     }()
     
     private lazy var menuList: UITableView = {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/ThemesSettingViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/ThemesSettingViewController.swift
@@ -17,7 +17,7 @@ final class ThemesSettingViewController: UIViewController {
     private var selectIndexPath = IndexPath(row: 0, section: 0)
         
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left,rightTitle: "Confirm".chat.localize)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left,rightTitle: "Confirm".chat.localize)
     }()
     
     private lazy var infoList: UITableView = {

--- a/EaseChatDemo/EaseChatDemo/Me/Controllers/TranslateLanguageSettingController.swift
+++ b/EaseChatDemo/EaseChatDemo/Me/Controllers/TranslateLanguageSettingController.swift
@@ -17,7 +17,7 @@ final class TranslateLanguageSettingController: UIViewController {
     private var languageRawValues = ["zh-Hans","en"]
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: NavigationHeight),textAlignment: .left)
     }()
     
     private lazy var infoList: UITableView = {

--- a/EaseChatDemo/EaseChatDemo/ServerConfigViewController.swift
+++ b/EaseChatDemo/EaseChatDemo/ServerConfigViewController.swift
@@ -17,7 +17,7 @@ final class ServerConfigViewController: UIViewController {
     }()
     
     private lazy var navigation: ChatNavigationBar = {
-        ChatNavigationBar(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: 44),textAlignment: .left,rightTitle: "保存".chat.localize)
+        ChatNavigationBar(show: CGRect(x: 0, y: 0, width: self.view.frame.width, height: 44),textAlignment: .left,rightTitle: "保存".chat.localize)
     }()
     
     private lazy var applicationField: UITextField = {


### PR DESCRIPTION
`ChatNavigationBar`中参数`frame`的外部参数名称为`show`。

```swift
/// EaseChatNavigationBar init method with right item kind of text.
/// - Parameters:
///   - textAlignment: ``NSTextAlignment``
///   - rightTitle: Title of the right item.
@objc public convenience init(show frame: CGRect = CGRect(x: 0, y: 0, width: ScreenWidth, height: NavigationHeight),textAlignment: NSTextAlignment = .center,rightTitle: String? = nil)
```

https://github.com/easemob/easemob-uikit-ios/blob/main/Sources/EaseChatUIKit/Classes/UI/Core/UIKit/Commons/ChatNavigationBar.swift#L219